### PR TITLE
Prevent PHP strict error about passing non-variable by reference

### DIFF
--- a/taxonomy-field.php
+++ b/taxonomy-field.php
@@ -204,7 +204,8 @@ class ACF_Taxonomy_Field extends acf_Field {
 		
 		//Build the base relative uri by searching backwards until we encounter the wordpress ABSPATH
 		//This may not work if the $base_dir contains a symlink outside of the WordPress ABSPATH
-		$root = array_pop( explode( DIRECTORY_SEPARATOR, rtrim( realpath( ABSPATH ), '/' ) ) );
+		$array = explode( DIRECTORY_SEPARATOR, rtrim( realpath( ABSPATH ), '/' ) );
+		$root = array_pop($array);
 		$path_parts = explode( DIRECTORY_SEPARATOR, $this->base_dir );
 		$parts = array();
 		while( $part = array_pop( $path_parts ) ) {


### PR DESCRIPTION
Fixes a PHP strict error about passing non-variable by reference by assigning the result of an complicated explode to a variable before passing it to array_pop
